### PR TITLE
ur_robot_driver builds on windows

### DIFF
--- a/controller_stopper/include/controller_stopper/controller_stopper.h
+++ b/controller_stopper/include/controller_stopper/controller_stopper.h
@@ -33,6 +33,8 @@
 class ControllerStopper
 {
 public:
+//
+//
   ControllerStopper() = delete;
   ControllerStopper(const ros::NodeHandle& nh);
   virtual ~ControllerStopper() = default;

--- a/controller_stopper/include/controller_stopper/controller_stopper.h
+++ b/controller_stopper/include/controller_stopper/controller_stopper.h
@@ -33,8 +33,6 @@
 class ControllerStopper
 {
 public:
-//
-//
   ControllerStopper() = delete;
   ControllerStopper(const ros::NodeHandle& nh);
   virtual ~ControllerStopper() = default;

--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ur_controllers)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -56,20 +56,30 @@ catkin_package(
 )
 
 # check c++11 / c++0x
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
-check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  add_compile_options(-std=c++11)
-elseif(COMPILER_SUPPORTS_CXX0X)
-  add_compile_options(-std=c++0x)
+if(NOT MSVC)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+  check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+  if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(-std=c++11)
+  elseif(COMPILER_SUPPORTS_CXX0X)
+    add_compile_options(-std=c++0x)
+  else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+  endif()
+
+  add_compile_options(-Wextra)
+  add_compile_options(-Wall)
+  add_compile_options(-Wno-unused-parameter)
 else()
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+
+  add_compile_options(/W3 /WX /wd4068)
 endif()
 
-add_compile_options(-Wall)
-add_compile_options(-Wextra)
-add_compile_options(-Wno-unused-parameter)
+
 
 
 include_directories(
@@ -106,7 +116,10 @@ add_library(ur_robot_driver
     src/ur/tool_communication.cpp
     src/rtde/rtde_writer.cpp
 )
-target_link_libraries(ur_robot_driver ${catkin_LIBRARIES})
+target_link_libraries(ur_robot_driver
+    ${catkin_LIBRARIES}
+    Ws2_32.lib
+    )
 add_dependencies(ur_robot_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_library(ur_robot_driver_plugin

--- a/ur_robot_driver/include/ur_robot_driver/comm/bin_parser.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/bin_parser.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <assert.h>
-#include <endian.h>
+#include <ur_robot_driver/portable_endian.h>
 #include <inttypes.h>
 #include <array>
 #include <bitset>

--- a/ur_robot_driver/include/ur_robot_driver/comm/package_serializer.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/package_serializer.h
@@ -28,7 +28,7 @@
 #ifndef UR_RTDE_DRIVER_PACKAGE_SERIALIZER_H_INCLUDED
 #define UR_RTDE_DRIVER_PACKAGE_SERIALIZER_H_INCLUDED
 
-#include <endian.h>
+#include <ur_robot_driver/portable_endian.h>
 #include <cstring>
 
 namespace ur_driver

--- a/ur_robot_driver/include/ur_robot_driver/comm/pipeline.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/pipeline.h
@@ -344,6 +344,8 @@ private:
   void runProducer()
   {
     LOG_DEBUG("Starting up producer");
+
+#ifndef WIN32
     std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
     bool has_realtime;
     realtime_file >> has_realtime;
@@ -396,6 +398,8 @@ private:
     {
       LOG_WARN("No realtime capabilities found. Consider using a realtime system for better performance");
     }
+  #endif
+  
     std::vector<std::unique_ptr<_package_type>> products;
     while (running_)
     {

--- a/ur_robot_driver/include/ur_robot_driver/comm/reverse_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/reverse_interface.h
@@ -31,7 +31,7 @@
 #include "ur_robot_driver/comm/server.h"
 #include "ur_robot_driver/types.h"
 #include <cstring>
-#include <endian.h>
+#include <ur_robot_driver/portable_endian.h>
 
 namespace ur_driver
 {
@@ -128,7 +128,7 @@ public:
    */
   std::string readKeepalive()
   {
-    size_t buf_len = 16;
+    const size_t buf_len = 16;
     char buffer[buf_len];
 
     bool read_successful = server_.readLine(buffer, buf_len);

--- a/ur_robot_driver/include/ur_robot_driver/comm/script_sender.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/script_sender.h
@@ -92,7 +92,7 @@ private:
 
   bool requestRead()
   {
-    size_t buf_len = 1024;
+    const size_t buf_len = 1024;
     char buffer[buf_len];
 
     bool read_successful = server_.readLine(buffer, buf_len);

--- a/ur_robot_driver/include/ur_robot_driver/comm/server.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/server.h
@@ -19,14 +19,14 @@
  */
 
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <atomic>
 #include <cstdlib>
 #include <mutex>
 #include <string>
 #include "ur_robot_driver/comm/tcp_socket.h"
+
+struct sockaddr;
 
 namespace ur_driver
 {

--- a/ur_robot_driver/include/ur_robot_driver/comm/stream.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/stream.h
@@ -19,8 +19,7 @@
  */
 
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
+
 #include <sys/types.h>
 #include <atomic>
 #include <mutex>
@@ -107,7 +106,7 @@ public:
 protected:
   virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
   {
-    return ::connect(socket_fd, address, address_len) == 0;
+    return ::connect(socket_fd, address, static_cast<int>(address_len)) == 0;
   }
 
 private:

--- a/ur_robot_driver/include/ur_robot_driver/comm/tcp_socket.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/tcp_socket.h
@@ -19,18 +19,22 @@
  */
 
 #pragma once
-#include <netdb.h>
-#include <sys/socket.h>
+#ifdef WIN32
+#include <ws2tcpip.h>
+#endif
 #include <sys/types.h>
 #include <atomic>
 #include <mutex>
 #include <string>
 #include <memory>
 
+struct sockaddr;
+
 namespace ur_driver
 {
 namespace comm
 {
+
 /*!
  * \brief State the socket can be in
  */

--- a/ur_robot_driver/include/ur_robot_driver/portable_endian.h
+++ b/ur_robot_driver/include/ur_robot_driver/portable_endian.h
@@ -1,0 +1,154 @@
+/**
+ * @file portable_endian.h
+ *
+ * Endianness conversion functions for a wide variety of systems,
+ * including Linux, FreeBSD, MacOS X and Windows.
+ */
+
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+#define __WINDOWS__
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+#include <endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+#elif defined(__OpenBSD__)
+#include <sys/endian.h>
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
+
+#define be16toh(x) betoh16(x)
+#define le16toh(x) letoh16(x)
+
+#define be32toh(x) betoh32(x)
+#define le32toh(x) letoh32(x)
+
+#define be64toh(x) betoh64(x)
+#define le64toh(x) letoh64(x)
+#elif defined(__WINDOWS__)
+#include <ws2tcpip.h>
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+#elif BYTE_ORDER == BIG_ENDIAN
+/* That would be Xbox 360. */
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+#else
+#error byte order not supported
+#endif
+
+//#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+#else
+#error platform not supported
+#endif
+
+#ifdef __cplusplus
+
+#include <cstdint>
+#include <cstring>
+
+#else
+
+#include <stdint.h>
+#include <string.h>
+
+#endif
+
+// libcaer: define macros for floating-point conversions too.
+// Floats must be 4 bytes in size, so like a 32-bit integer, but their endianness
+// is undefined, so we use the 32bit conversion functions and memcpy() to do the
+// conversions safely (assumed integer and floating-point do have the same
+// endianness on the system, which is almost always true). For further details, see:
+// https://stackoverflow.com/questions/10620601/portable-serialisation-of-ieee754-floating-point-values
+static inline float htobeflt(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = htobe32(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float htoleflt(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = htole32(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float beflttoh(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = be32toh(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+static inline float leflttoh(float val) {
+	uint32_t rep;
+	memcpy(&rep, &val, sizeof(rep));
+	rep = le32toh(rep);
+	memcpy(&val, &rep, sizeof(rep));
+	return (val);
+}
+
+#endif /* PORTABLE_ENDIAN_H__ */

--- a/ur_robot_driver/include/ur_robot_driver/primary/package_header.h
+++ b/ur_robot_driver/include/ur_robot_driver/primary/package_header.h
@@ -31,7 +31,7 @@
 
 #include <inttypes.h>
 #include <cstddef>
-#include <endian.h>
+#include <ur_robot_driver/portable_endian.h>
 #include "ur_robot_driver/types.h"
 
 namespace ur_driver

--- a/ur_robot_driver/include/ur_robot_driver/rtde/package_header.h
+++ b/ur_robot_driver/include/ur_robot_driver/rtde/package_header.h
@@ -30,7 +30,7 @@
 #define UR_RTDE_DRIVER_RTDE__HEADER_H_INCLUDED
 
 #include <cstddef>
-#include <endian.h>
+#include <ur_robot_driver/portable_endian.h>
 #include "ur_robot_driver/types.h"
 #include "ur_robot_driver/comm/package_serializer.h"
 
@@ -84,10 +84,10 @@ public:
    *
    * \returns
    */
-  static size_t serializeHeader(uint8_t* buffer, PackageType package_type, uint16_t payload_length)
+  static size_t serializeHeader(uint8_t* buffer, PackageType package_type, size_t payload_length)
   {
-    uint16_t header_size = sizeof(_package_size_type) + sizeof(PackageType);
-    uint16_t size = header_size + payload_length;
+    size_t header_size = sizeof(_package_size_type) + sizeof(PackageType);
+    size_t size = header_size + payload_length;
     comm::PackageSerializer::serialize(buffer, size);
     comm::PackageSerializer::serialize(buffer + sizeof(size), package_type);
     return header_size;

--- a/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
@@ -80,7 +80,7 @@ public:
 protected:
   virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
   {
-    return ::connect(socket_fd, address, address_len) == 0;
+    return ::connect(socket_fd, address, static_cast<int>(address_len)) == 0;
   }
 
 private:

--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -13,7 +13,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in  writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
@@ -21,9 +21,14 @@
  */
 
 #include "ur_robot_driver/comm/server.h"
+#ifndef WIN32
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
+#else
+#include <ws2tcpip.h>
+typedef int socklen_t;
+#endif
 #include <cstring>
 #include "ur_robot_driver/log.h"
 
@@ -60,8 +65,8 @@ std::string URServer::getIP()
 bool URServer::open(int socket_fd, struct sockaddr* address, size_t address_len)
 {
   int flag = 1;
-  setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
-  return ::bind(socket_fd, address, address_len) == 0;
+  setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&flag), sizeof(int));
+  return ::bind(socket_fd, address, static_cast<int>(address_len)) == 0;
 }
 
 bool URServer::bind()

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -294,8 +294,8 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   speedsc_interface_.registerHandle(
       ur_controllers::SpeedScalingHandle("speed_scaling_factor", &speed_scaling_combined_));
 
-  fts_interface_.registerHandle(hardware_interface::ForceTorqueSensorHandle(
-      "wrench", tf_prefix_ + "tool0_controller", fts_measurements_.begin(), fts_measurements_.begin() + 3));
+  fts_interface_.registerHandle(hardware_interface::ForceTorqueSensorHandle(hardware_interface::ForceTorqueSensorHandle(
+      "wrench", tf_prefix_ + "tool0_controller", &fts_measurements_[0], &fts_measurements_[3])));
 
   // Register interfaces
   registerInterface(&js_interface_);
@@ -312,19 +312,19 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   io_pub_->msg_.digital_out_states.resize(actual_dig_out_bits_.size());
   io_pub_->msg_.analog_in_states.resize(standard_analog_input_.size());
   io_pub_->msg_.analog_out_states.resize(standard_analog_output_.size());
-  for (size_t i = 0; i < actual_dig_in_bits_.size(); ++i)
+  for (UINT8 i = 0; i < actual_dig_in_bits_.size(); ++i)
   {
     io_pub_->msg_.digital_in_states[i].pin = i;
   }
-  for (size_t i = 0; i < actual_dig_out_bits_.size(); ++i)
+  for (UINT8 i = 0; i < actual_dig_out_bits_.size(); ++i)
   {
     io_pub_->msg_.digital_out_states[i].pin = i;
   }
-  for (size_t i = 0; i < standard_analog_input_.size(); ++i)
+  for (UINT8 i = 0; i < standard_analog_input_.size(); ++i)
   {
     io_pub_->msg_.analog_in_states[i].pin = i;
   }
-  for (size_t i = 0; i < standard_analog_output_.size(); ++i)
+  for (UINT8 i = 0; i < standard_analog_output_.size(); ++i)
   {
     io_pub_->msg_.analog_out_states[i].pin = i;
   }

--- a/ur_robot_driver/src/ros/hardware_interface_node.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface_node.cpp
@@ -56,6 +56,7 @@ int main(int argc, char** argv)
   // register signal SIGINT and signal handler
   signal(SIGINT, signalHandler);
 
+#ifndef WIN32
   std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
   bool has_realtime;
   realtime_file >> has_realtime;
@@ -104,6 +105,7 @@ int main(int argc, char** argv)
       ROS_ERROR("Could not get maximum thread priority for main thread");
     }
   }
+#endif
 
   // Set up timers
   ros::Time timestamp;

--- a/ur_robot_driver/src/ros/robot_state_helper.cpp
+++ b/ur_robot_driver/src/ros/robot_state_helper.cpp
@@ -28,6 +28,7 @@
 #include <ur_robot_driver/ros/robot_state_helper.h>
 
 #include <std_srvs/Trigger.h>
+#include <thread>
 namespace ur_driver
 {
 RobotStateHelper::RobotStateHelper(const ros::NodeHandle& nh) : nh_(nh), set_mode_as_(nh_, "set_mode", false)
@@ -79,6 +80,7 @@ void RobotStateHelper::safetyModeCallback(const ur_dashboard_msgs::SafetyMode& m
 
 void RobotStateHelper::updateRobotState()
 {
+  using namespace std::chrono_literals;
   if (set_mode_as_.isActive())
   {
     // Update action feedback
@@ -103,7 +105,7 @@ void RobotStateHelper::updateRobotState()
       if (robot_mode_ == RobotMode::RUNNING && goal_->play_program)
       {
         // The dashboard denies playing immediately after switching the mode to RUNNING
-        sleep(1);
+        std::this_thread::sleep_for(1ms);
         safeDashboardTrigger(&this->play_program_srv_);
       }
 

--- a/ur_robot_driver/src/rtde/control_package_setup_inputs.cpp
+++ b/ur_robot_driver/src/rtde/control_package_setup_inputs.cpp
@@ -58,7 +58,7 @@ size_t ControlPackageSetupInputsRequest::generateSerializedRequest(uint8_t* buff
   for (const auto& piece : variable_names)
     variables += (piece + ",");
   variables.pop_back();
-  uint16_t payload_size = variables.size();
+  size_t payload_size = variables.size();
 
   size_t size = 0;
   size += PackageHeader::serializeHeader(buffer, PACKAGE_TYPE, payload_size);

--- a/ur_robot_driver/src/rtde/control_package_setup_outputs.cpp
+++ b/ur_robot_driver/src/rtde/control_package_setup_outputs.cpp
@@ -58,7 +58,7 @@ size_t ControlPackageSetupOutputsRequest::generateSerializedRequest(uint8_t* buf
   for (const auto& piece : variable_names)
     variables += (piece + ",");
   variables.pop_back();
-  uint16_t payload_size = sizeof(double) + variables.size();
+  size_t payload_size = sizeof(double) + variables.size();
 
   size_t size = 0;
   size += PackageHeader::serializeHeader(buffer, PACKAGE_TYPE, payload_size);
@@ -79,7 +79,7 @@ size_t ControlPackageSetupOutputsRequest::generateSerializedRequest(uint8_t* buf
   for (const auto& piece : variable_names)
     variables += (piece + ",");
   variables.pop_back();
-  uint16_t payload_size = variables.size();
+  size_t payload_size = variables.size();
 
   size_t size = 0;
   size += PackageHeader::serializeHeader(buffer, PACKAGE_TYPE, payload_size);


### PR DESCRIPTION
Fixes for build errors on Windows including:
- build flags
- switching to portable_endian.h
- using winsock2
- using std::chrono_literals instead of sleep()

builds with ` (catkin_make_isolated --only-pkg-with-deps ur_robot_driver --install) `

While testing with robot hardware, received a pipeline error:
` Pipeline producer overflowed! <RTDE Data Pipeline>`
